### PR TITLE
開発環境の整理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /build
 /.vscode
 /node_modules
+.wp-env.override.json
 webpack.config.local.js

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "scripts": {
         "set-wpcs": [
-            "./vendor/bin/phpcs --config-set installed_paths `pwd -P`/vendor/phpcompatibility/php-compatibility,`pwd -P`/vendor/phpcompatibility/phpcompatibility-paragonie,`pwd -P`/vendor/phpcompatibility/phpcompatibility-wp,`pwd -P`/vendor/wp-coding-standards/wpcs"
+            "phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility,vendor/phpcompatibility/phpcompatibility-paragonie,vendor/phpcompatibility/phpcompatibility-wp,vendor/wp-coding-standards/wpcs"
         ]
     }
 }


### PR DESCRIPTION
# .wp-env.override.jsonをgit管理から除外
wp-envの設定をローカル環境で上書きするためのjsonファイルをgitignoreに追加しました。

# composer scriptsの記述をOSに依存しないよう修正
`pwd`はLinuxコマンドでWindows環境では使えないため、OS依存コマンドは使用せず相対パス指定に変更しました。