### PR TITLE
カスタムブロックのコンソールエラー修正

### DIFF
--- a/src/gutenberg/blocks/accordion/_sidebar.js
+++ b/src/gutenberg/blocks/accordion/_sidebar.js
@@ -35,7 +35,6 @@ export default ({ iconOpened, updateIcons }) => {
 						const isActive = iconSet.opened === iconOpened;
 						return (
 							<Button
-								isLarge
 								isPrimary={isActive}
 								onClick={() => {
 									updateIcons({

--- a/src/gutenberg/blocks/button/_sidebar.js
+++ b/src/gutenberg/blocks/button/_sidebar.js
@@ -197,7 +197,6 @@ export default ({ attributes, setAttributes, clientId }) => {
 									}
 									return (
 										<Button
-											isLarge
 											isSecondary={!isPrimary}
 											isPrimary={isPrimary}
 											onClick={() => {

--- a/src/gutenberg/blocks/post-list/panel/_display.js
+++ b/src/gutenberg/blocks/post-list/panel/_display.js
@@ -264,7 +264,7 @@ export default function ({ attributes, setAttributes }) {
 								onClick={() => {
 									setAttributes({ order: btn.val });
 								}}
-								key={`order_${order.val}`}
+								key={`order_${btn.val}`}
 							>
 								{btn.label}
 							</Button>

--- a/src/gutenberg/blocks/step/_sidebar.js
+++ b/src/gutenberg/blocks/step/_sidebar.js
@@ -33,7 +33,6 @@ export default function ({ attributes, setAttributes }) {
 					</BaseControl.VisualLabel>
 					<ButtonGroup className='swl-btns--padSmall'>
 						<Button
-							isLarge
 							isPrimary={'vertical' === numLayout}
 							onClick={() => {
 								setAttributes({ numLayout: 'vertical' });
@@ -42,7 +41,6 @@ export default function ({ attributes, setAttributes }) {
 							縦並び
 						</Button>
 						<Button
-							isLarge
 							isPrimary={'horizontal' === numLayout}
 							onClick={() => {
 								setAttributes({ numLayout: 'horizontal' });
@@ -59,7 +57,6 @@ export default function ({ attributes, setAttributes }) {
 					</BaseControl.VisualLabel>
 					<ButtonGroup className='swl-btns--padSmall'>
 						<Button
-							isLarge
 							isPrimary={'circle' === numShape}
 							onClick={() => {
 								setAttributes({ numShape: 'circle' });
@@ -68,7 +65,6 @@ export default function ({ attributes, setAttributes }) {
 							円形
 						</Button>
 						<Button
-							isLarge
 							isPrimary={'square' === numShape}
 							onClick={() => {
 								setAttributes({ numShape: 'square' });


### PR DESCRIPTION
+ mapのkeyがundefinedになっていた問題を修正。
+ Buttonコンポーネント `isLarge` 属性がWordPress5.5から定義されなくなり、コンソールエラーが出ていたため削除。
https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2922